### PR TITLE
discord: add flag to disable zippath

### DIFF
--- a/my/discord/data_export.py
+++ b/my/discord/data_export.py
@@ -117,14 +117,14 @@ def test_remove_link_suppression() -> None:
 
 
 def _cachew_depends_on() -> List[str]:
-    return [str(p) for p in get_files(config.export_path, guess_compression=config.guess_compression)]
+    return [str(p) for p in get_files(config.export_path)]
 
 
 EXPECTED_DISCORD_STRUCTURE = ("messages/index.json", "account/user.json")
 
 
 def get_discord_exports() -> Iterator[Path]:
-    for exp in get_files(config.export_path):
+    for exp in get_files(config.export_path, guess_compression=config._use_zippath):
         # weak type check here, ZipPath is a bit experimental, so don't want a dependency
         # see https://github.com/karlicoss/HPI/blob/master/my/core/kompress.py#L160
         if type(exp).__name__ == "ZipPath":

--- a/my/discord/data_export.py
+++ b/my/discord/data_export.py
@@ -1,6 +1,7 @@
 """
 Discord Data: messages and events data
 """
+
 REQUIRES = [
     "git+https://github.com/seanbreckenridge/discord_data",
     "urlextract",
@@ -11,21 +12,31 @@ from pathlib import Path
 from typing import List
 
 from my.config import discord as user_config  # type: ignore[attr-defined]
-from my.core import PathIsh, dataclass
+from my.core import PathIsh, dataclass, make_config
+from my.core.common import mcachew
 
 
 @dataclass
-class config(user_config.data_export):
+class discord_config(user_config.data_export):
     # path to the top level discord export directory
     # see https://github.com/seanbreckenridge/discord_data for more info
     export_path: PathIsh
+
+    # whether to guess the compression of the files in the export_path
+    # this uses kompress.ZipPath, which is a bit experimental
+    #
+    # NOTE: before adding this config flag, this was enabled,
+    # since guess_compression=True on get_files by default
+    _use_zippath: bool = True
+
+
+config = make_config(discord_config)
 
 
 from typing import Iterator, Optional, Tuple, Set, NamedTuple
 from datetime import datetime
 
 from my.core import make_logger, Stats, get_files
-from my.core.common import mcachew
 from my.core.structure import match_structure
 from discord_data.parse import parse_messages, parse_activity
 from discord_data.model import Activity, Message
@@ -106,7 +117,7 @@ def test_remove_link_suppression() -> None:
 
 
 def _cachew_depends_on() -> List[str]:
-    return [str(p) for p in get_files(config.export_path)]
+    return [str(p) for p in get_files(config.export_path, guess_compression=config.guess_compression)]
 
 
 EXPECTED_DISCORD_STRUCTURE = ("messages/index.json", "account/user.json")


### PR DESCRIPTION
If I dont do this, I get logs like these and it seems that the file is not being read:

```
[WARNING 2024-02-08 12:06:05,556 my.discord.data_export data_export.py:135 ] Message index 'index.json' doesn't exist at /home/sean/data/discord/2020_10.zip/messages/index.json
[WARNING 2024-02-08 12:06:05,572 my.discord.data_export data_export.py:135 ] Message index 'index.json' doesn't exist at /home/sean/data/discord/2021_03.zip/messages/index.json
[WARNING 2024-02-08 12:06:05,588 my.discord.data_export data_export.py:135 ] Message index 'index.json' doesn't exist at /home/sean/data/discord/2021_11.zip/messages/index.json
[WARNING 2024-02-08 12:06:05,606 my.discord.data_export data_export.py:135 ] Message index 'index.json' doesn't exist at /home/sean/data/discord/2022_04.zip/messages/index.json
[WARNING 2024-02-08 12:06:05,624 my.discord.data_export data_export.py:135 ] Message index 'index.json' doesn't exist at /home/sean/data/discord/2022_11_27.zip/messages/index.json
```

I think this probably has to do with the inconsistent directory depth I have on my discord exports (I had unzipped/rezipped some of them while testing things) but it means that `match_structure` is not being run in `get_discord_exports`, so it doesnt find the correct files

Just as an FYI, @karlicoss

I added an experimental `._use_zippath` config flag for now, which I now have set to `False` for myself (otherwise it would default to true since `guess_compression=True` on `get_files`), so it does the whole `match_structure` unzip in my tmpdir, but maybe it would be nice to have a global config option for `get_files` to set `guess_compression` across everything?

Perhaps explicitly for `ZipPath` in particular, since that tends to be a directory structure that might cause issues. Things like `.gz`/`.zstd` are typically just parsing one compressed file